### PR TITLE
Add professional & freshMart catalogues

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "react-router-dom": "^5.2.0",
     "redux": "^4.0.5",
     "redux-devtools-extension": "^2.13.8",
-    "redux-saga": "^1.1.3"
+    "redux-saga": "^1.1.3",
+    "rer": "^0.1.7"
   },
   "devDependencies": {
     "@babel/core": "^7.9.6",

--- a/src/screens/artisans/index.css
+++ b/src/screens/artisans/index.css
@@ -1,13 +1,15 @@
 .Artisan__container {
     display: flex;
-    flex-direction: row;
     flex-wrap: wrap;
+    margin: 5% auto;
+    width: 100%;
 }
 .Artisan__card {
     color: rgb(59, 57, 57);
-    max-width: 25rem;
-    margin: 0.5rem;
+    width: 32%;
+    margin: 1% auto;
 }
+.Artisan__card img{max-height: 10rem;}
 
 .Artisan__card .Artisan__Overlay {
     display: none;
@@ -22,12 +24,15 @@
     color: gold;
     text-align: justify;
     overflow: hidden;
+    padding: auto;
 }
 
 .Artisan__Overlay Button {
     text-align: center;
     color: #000;
+    margin-left: auto;
+    margin-right: auto;
     position: absolute;
     bottom: 2px;
-    left: 30%;
+    /* left: auto; */
 }

--- a/src/screens/artisans/index.js
+++ b/src/screens/artisans/index.js
@@ -17,7 +17,7 @@ const Artisans = ({ getAllProducts, products }) => {
   const items = products.all.data.rows;
 
   return (
-    <div className="Artisan__container">
+    <div className="container Artisan__container">
          {items.map((item) => (
              <Artisan key={item.product_id} product={item} />
          ))}

--- a/src/screens/freshmart/Freshy.js
+++ b/src/screens/freshmart/Freshy.js
@@ -1,0 +1,21 @@
+import React, { useEffect } from 'react';
+import { Card, Button } from 'react-bootstrap';
+import PropTypes from 'prop-types';
+
+export const Freshy = ({ product }) => {
+    const { description, name, price, thumbnail } = product;
+    return (
+        <Card style={{ width: '18rem', margin: 20 }}>
+          <Card.Img variant="top" src={`https://backendapi.turing.com/images/products/${thumbnail}`} alt={name} />
+          <Card.Body>
+            <Card.Title>{name}</Card.Title>
+            <Card.Text>{description}</Card.Text>
+            <Button variant="outlined primary">${price}</Button>
+          </Card.Body>
+        </Card>
+    );
+};
+
+Freshy.propTypes = {
+    product: PropTypes.object.isRequired
+}

--- a/src/screens/freshmart/index.js
+++ b/src/screens/freshmart/index.js
@@ -1,2 +1,52 @@
-import React from 'react'
-export const FreshMart =  () => <h1>Welcome to Freshmart</h1>
+import React, { useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { Freshy } from './Freshy';
+import { getAllProducts } from '../../store/actions';
+
+export const FreshMart =  ({ getAllProducts, products }) => {
+    useEffect(() => {
+        getAllProducts({
+            page: 1,
+            limit: 9,
+            description_length: 120
+        });
+    }, []);
+    console.log(2, products);
+
+    const items = products.all.data.rows;
+
+    return (
+        <div style={styles}>
+            {items.map((item) => (
+                <Freshy key={item.product_id} product={item} />
+            ))}
+        </div>
+    )
+
+};
+
+const styles = {
+    padding: '10vw',
+    margin: 'auto',
+    display: 'flex',
+    flexDirection: 'row',
+    flexWrap: 'wrap'
+};
+
+FreshMart.propTypes = {
+    getAllProducts: PropTypes.func,
+    products: PropTypes.object
+};
+
+const mapStateToProps = ({ products }) => {
+    return {
+        products
+    };
+};
+
+const mapDispatchToProp = {
+    getAllProducts
+}
+
+export default connect(mapStateToProps, mapDispatchToProp)(FreshMart);

--- a/src/screens/index.js
+++ b/src/screens/index.js
@@ -1,6 +1,6 @@
 import Home from './home';
-import { FreshMart } from './freshmart';
+import FreshMart from './freshmart';
 import Artisans from './artisans';
-import { Professionals } from './professionals';
+import  Professionals  from './professionals';
 
 export { Home, Artisans, FreshMart, Professionals };

--- a/src/screens/professionals/Profession.js
+++ b/src/screens/professionals/Profession.js
@@ -2,11 +2,10 @@ import React from 'react';
 import { Card, Button } from 'react-bootstrap';
 import PropTypes from 'prop-types';
 
-export const Artisan = ({ product }) => {
 
-    // const { banner_pic, name, service, detail_desc, contact } = product;
-    const { description, name, price, thumbnail } = product;
-    const first_name = name.split(" ")[0]
+export const Profession = ({ product }) => {
+    const { name, price, thumbnail, description } = product;
+
     return (
         <Card className="Artisan__card">
           <Card.Img src={`https://backendapi.turing.com/images/products/${thumbnail}`} alt={name} />
@@ -14,7 +13,7 @@ export const Artisan = ({ product }) => {
              <Card.Text>
                {description}
              </Card.Text>
-             <Button>Hire {first_name}</Button>
+             <Button>Contact Me {name}</Button>
           </Card.ImgOverlay>
           <Card.Body>
             <Card.Title> {name} </Card.Title>
@@ -24,7 +23,8 @@ export const Artisan = ({ product }) => {
     )
 }
 
-Artisan.propTypes = {
-  product: PropTypes.object.isRequired
-};
+Profession.propTypes = {
+    product: PropTypes.object.isRequired
+}
 
+// export default Profession;

--- a/src/screens/professionals/index.js
+++ b/src/screens/professionals/index.js
@@ -1,2 +1,44 @@
-import React from 'react'
-export const Professionals =  () => <h1>Welcome to Professionals</h1>
+import React, { useEffect } from 'react'
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { getAllProducts } from '../../store/actions';
+import { Profession } from './Profession';
+
+
+const Professionals =  ({ getAllProducts, products }) => {
+    useEffect(() => {
+        getAllProducts({
+            page: 1,
+            limit: 9,
+            description_length: 120
+        });
+    }, []);
+    console.log(2, products);
+
+    const items = products.all.data.rows;
+
+    return (
+        <div className="container Artisan__container">
+            {items.map((item) => (
+                <Profession key={item.product_id} product={item} />
+            ))}
+        </div>
+    )
+}
+
+Professionals.propTypes = {
+    getAllProducts: PropTypes.func,
+    products: PropTypes.object
+}
+
+const mapStateToProps = ({ products }) => {
+    return {
+        products
+    }
+};
+
+const mapDispatchToProp = {
+    getAllProducts
+}
+
+export default connect(mapStateToProps, mapDispatchToProp)(Professionals);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2337,6 +2337,14 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+cross-spawn@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.2.tgz#7b9247621c23adfdd3856004a823cbe397424d41"
+  integrity sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=
+  dependencies:
+    lru-cache "^4.0.1"
+    which "^1.2.9"
+
 cross-spawn@^6.0.0, cross-spawn@^6.0.4, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -3129,6 +3137,19 @@ exec-sh@^0.3.2:
   resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.3.4.tgz#3a018ceb526cc6f6df2bb504b2bfe8e3a4934ec5"
   integrity sha512-sEFIkc61v75sWeOe72qyrqg2Qg0OuLESziUDk/O/z2qgS15y2gWVFrI6f2Qn/qw/0/NCfCEsmNA4zOjkwEZT1A==
 
+execa@^0.5.0:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.5.1.tgz#de3fb85cb8d6e91c85bcbceb164581785cb57b36"
+  integrity sha1-3j+4XLjW6RyFvLzrFkWBeFy1ezY=
+  dependencies:
+    cross-spawn "^4.0.0"
+    get-stream "^2.2.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
+
 execa@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-1.0.0.tgz#c6236a5bb4df6d6f15e88e7f017798216749ddd8"
@@ -3452,6 +3473,14 @@ get-port@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/get-port/-/get-port-3.2.0.tgz#dd7ce7de187c06c8bf353796ac71e099f0980ebc"
   integrity sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw=
+
+get-stream@^2.2.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-2.3.1.tgz#5f38f93f346009666ee0150a054167f91bdd95de"
+  integrity sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=
+  dependencies:
+    object-assign "^4.0.1"
+    pinkie-promise "^2.0.0"
 
 get-stream@^4.0.0:
   version "4.1.0"
@@ -4857,6 +4886,14 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
+lru-cache@^4.0.1:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
+  integrity sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
+  dependencies:
+    pseudomap "^1.0.2"
+    yallist "^2.1.2"
+
 magic-string@^0.22.4:
   version "0.22.5"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.22.5.tgz#8e9cf5afddf44385c1da5bc2a6a0dbd10b03657e"
@@ -5218,7 +5255,7 @@ oauth-sign@~0.9.0:
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
-object-assign@^4.1.1:
+object-assign@^4.0.1, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
@@ -5656,6 +5693,18 @@ pify@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
   integrity sha1-7RQaasBDqEnqWISY59yosVMw6Qw=
+
+pinkie-promise@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa"
+  integrity sha1-ITXW36ejWMBprJsXh3YogihFD/o=
+  dependencies:
+    pinkie "^2.0.0"
+
+pinkie@^2.0.0:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
+  integrity sha1-clVrgM+g1IqXToDnckjoDtT3+HA=
 
 pirates@^4.0.1:
   version "4.0.1"
@@ -6123,6 +6172,11 @@ prop@0.1.1:
   dependencies:
     dotty "0.0.1"
 
+pseudomap@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
+  integrity sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
+
 psl@^1.1.28:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.8.0.tgz#9326f8bcfb013adcc005fdff056acce020e51c24"
@@ -6572,6 +6626,13 @@ require-main-filename@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
+
+rer@^0.1.7:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/rer/-/rer-0.1.7.tgz#e900cfd97c1a30054ff51c5530d260c25aecf7d8"
+  integrity sha1-6QDP2XwaMAVP9RxVMNJgwlrs99g=
+  dependencies:
+    execa "^0.5.0"
 
 resolve-cwd@^3.0.0:
   version "3.0.0"
@@ -7959,6 +8020,11 @@ y18n@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
   integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
+
+yallist@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
+  integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
 
 yargs-parser@^15.0.1:
   version "15.0.1"


### PR DESCRIPTION
## Description
@sunny775  In this PR, I worked on the index page for both FreshMart and Professionals
No dependency was required for the update made.

This PR is a partial fixes for #7 & #9

## How Has This Been Tested?
No test was written for this PR, although it's rendering as expected in line with the project structure

## Screenshots (if applicable, else remove this line / section)
See FreshMart screenshot below
![image](https://user-images.githubusercontent.com/41282717/82958202-c09b3100-9f69-11ea-9351-daca5acc462a.png)

See Professional screenshot below 
![image](https://user-images.githubusercontent.com/41282717/82958311-fe985500-9f69-11ea-9cce-d78790c5d40a.png)



## Checklist:
<!--- Put an `x` in all the boxes that apply ! -->
- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added necessary inline code documentation
- [ ] I have added tests that prove my fix is effective and that this feature works
- [ ] New and existing unit tests pass locally with my changes
