### PR TITLE
Replace $ with Icon link for an artisan

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "redux-devtools-extension": "^2.13.8",
     "redux-saga": "^1.1.3",
     "rer": "^0.1.7",
+    "rrr": "^0.1.1",
     "s": "^1.0.0",
     "style": "^0.0.3",
     "styled-components": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "redux-devtools-extension": "^2.13.8",
     "redux-saga": "^1.1.3",
     "rer": "^0.1.7",
-    "rrr": "^0.1.1",
     "s": "^1.0.0",
     "style": "^0.0.3",
     "styled-components": "^5.1.1",

--- a/src/components/ArtisanDetails.js
+++ b/src/components/ArtisanDetails.js
@@ -80,7 +80,7 @@ const ArtisanDetails = ({ getAnArtisan, artisan }) => {
                   </WishList>
                 </Col>
                 <Col sm={6} md={4}>
-                  <CartBtn size="sm">Add to cart</CartBtn>
+                  <CartBtn size="sm">Hire now</CartBtn>
                 </Col>
               </Row>
             </Actions>

--- a/src/components/artisans/Artisan.js
+++ b/src/components/artisans/Artisan.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { Card, Button } from 'react-bootstrap';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import config from '../../config/system';
 
@@ -33,16 +34,20 @@ const Title = styled(Card.Title)`
 `;
 
 export const Artisan = ({ artisan }) => {
-  const { description, name, filename } = artisan;
+  const { description, name, filename, _id } = artisan;
   return (
     <div>
       <ArtisanCard style={{ maxWidth: '14rem' }}>
+        <Link to={`artisans/${_id}/details`}>
         <Card.Img variant="top" src={`${config.ArtisanImageUrl}/${filename}`} style={{ height: 150 }} />
+        </Link>
         <Card.Body>
           <Title>{name}</Title>
           <Card.Text>{description.slice(0, 50)}</Card.Text>
            <Button size='sm' variant='default'>
+           <Link to={`artisans/${_id}/details`}>
            <FontAwesomeIcon icon="eye"/>
+           </Link>
            </Button>
             <CartBtn variant="primary" size="sm">
               Hire now

--- a/src/screens/artisans/main/featured_artisans/Artisan.js
+++ b/src/screens/artisans/main/featured_artisans/Artisan.js
@@ -3,6 +3,7 @@ import { Card, Button } from 'react-bootstrap';
 import {Link} from 'react-router-dom'
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import config from '../../../../config/system';
 
 const ArtisanCard = styled(Card)`
@@ -39,7 +40,11 @@ export const Artisan = ({ artisan }) => {
         <Card.Body>
           <Card.Title>{name}</Card.Title>
           <Card.Text>{description.slice(0, 50)}</Card.Text>
-          <Button variant=" outlined primary">${price}</Button>
+          <Button variant=" outlined primary">
+          <Link to={`artisans/${_id}/details`}>
+          <FontAwesomeIcon icon="eye"/>
+          </Link>
+          </Button>
           <CartBtn variant="primary" size='sm'>Hire now</CartBtn>
         </Card.Body>
       </ArtisanCard>

--- a/src/screens/artisans/main/featured_artisans/Artisan.js
+++ b/src/screens/artisans/main/featured_artisans/Artisan.js
@@ -30,7 +30,7 @@ const CartBtn = styled(Button)`
 `;
 
 export const Artisan = ({ artisan }) => {
-  const { description, name, price, filename, _id } = artisan;
+  const { description, name, filename, _id } = artisan;
   return (
     <div>
       <ArtisanCard style={{ maxWidth: '17rem'}}>

--- a/src/screens/artisans/main/featured_artisans/index.js
+++ b/src/screens/artisans/main/featured_artisans/index.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import styled from 'styled-components';
 import { CardColumns } from 'react-bootstrap';
+import { Loading } from '../../../../components/alerts/loading'
+import { ErrorAlert } from '../../../../components/alerts/errorAlert'
 import { Artisan } from './Artisan';
 import { getAllArtisans } from '../../../../store/actions';
 
@@ -30,16 +32,20 @@ const FeaturedArtisans = ({ getAllArtisans, artisans }) => {
     });
   }, []);
 
-  const items = artisans.all.data;
+  let { data, error, isLoading } = artisans.all;
+
+  const state = error ? <ErrorAlert /> : isLoading ? <Loading /> : null;
   return (
+    state || (
     <div>
       <LightHeading className="py-2">Featured Artisans</LightHeading>
       <Deck>
-        {items.map((item) => (
+        {data.map((item) => (
           <Artisan key={item._id} artisan={item} />
         ))}
       </Deck>
     </div>
+    )
   );
 };
 

--- a/src/screens/artisans/main/featured_artisans/index.js
+++ b/src/screens/artisans/main/featured_artisans/index.js
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import styled from 'styled-components';
 import { CardColumns } from 'react-bootstrap';
-import { Loading } from '../../../../components/alerts/loading'
-import { ErrorAlert } from '../../../../components/alerts/errorAlert'
+import { Loading } from '../../../../components/alerts/loading';
+import { ErrorAlert } from '../../../../components/alerts/errorAlert';
 import { Artisan } from './Artisan';
 import { getAllArtisans } from '../../../../store/actions';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2306,6 +2306,11 @@ commander@^2.11.0, commander@^2.19.0, commander@^2.20.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
+compiled-accessors@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/compiled-accessors/-/compiled-accessors-0.2.0.tgz#6c2efa8ba627e02d4460f1d88999f1b776b35da3"
+  integrity sha1-bC76i6Yn4C1EYPHYiZnxt3azXaM=
+
 component-emitter@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
@@ -6945,6 +6950,13 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
   dependencies:
     hash-base "^3.0.0"
     inherits "^2.0.1"
+
+rrr@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/rrr/-/rrr-0.1.1.tgz#e620058f37538f42116cd85b990252cdef8bc632"
+  integrity sha1-5iAFjzdTj0IRbNhbmQJSze+LxjI=
+  dependencies:
+    compiled-accessors "^0.2.0"
 
 rsvp@^4.8.4:
   version "4.8.5"


### PR DESCRIPTION
## Description
@sunny775 I have replaced the $ sign on each artisan with an `eye icon` and set it to link to `artisans/id/details`

## How Has This Been Tested?
Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code etc.

## Screenshots (if applicable, else remove this line / section)


## Checklist:
<!--- Put an `x` in all the boxes that apply ! -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added necessary inline code documentation
- [ ] I have added tests that prove my fix is effective and that this feature works
- [ ] New and existing unit tests pass locally with my changes
